### PR TITLE
allow the full range of parameters allowed by Term::ANSIColor

### DIFF
--- a/lib/Term/ANSIColor/Conditional.pm
+++ b/lib/Term/ANSIColor/Conditional.pm
@@ -52,7 +52,7 @@ sub color {
 
 # provide our own colored()
 sub colored {
-    return $_[1] unless _color_enabled();
+    return do { ref $_[0] ? shift : pop; @_ } unless _color_enabled();
     goto &Term::ANSIColor::colored;
 }
 


### PR DESCRIPTION
This fix fixes the output of this script:

```perl
#!/usr/bin/env perl

use v5.10;
use strict;
use warnings;

use Term::ANSIColor::Conditional;

for (0, 1) {
    $Term::ANSIColor::Conditional::COLOR = $_;
    say colored(['red'], 'colored with array: ', 'hi ', 'there ');
    say colored('yo man', 'red');
}
```

Before was (couldn't paste the colors here though):

```
colored with array: 
red
colored with array: hi there 
yo man
```

Now is:

```
colored with array: hi there 
yo man
colored with array: hi there 
yo man
```